### PR TITLE
[Console] Make `#[AsCommand]` attribute class `final`

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -17,6 +17,7 @@ AssetMapper
 Console
 -------
 
+ * The `AsCommand` attribute class is now `final`
  * Remove methods `Command::getDefaultName()` and `Command::getDefaultDescription()` in favor of the `#[AsCommand]` attribute
 
    *Before*

--- a/src/Symfony/Component/Console/Attribute/AsCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsCommand.php
@@ -13,11 +13,9 @@ namespace Symfony\Component\Console\Attribute;
 
 /**
  * Service tag to autoconfigure commands.
- *
- * @final since Symfony 7.3
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-class AsCommand
+final class AsCommand
 {
     /**
      * @param string      $name        The name of the command, used when calling it (i.e. "cache:clear")

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.0
 ---
 
+ * Make `AsCommand` attribute class final
  * Remove methods `Command::getDefaultName()` and `Command::getDefaultDescription()` in favor of the `#[AsCommand]` attribute
  * Ensure closures set via `Command::setCode()` method have proper parameter and return types
  * Add method `isSilent()` to `OutputInterface`


### PR DESCRIPTION
This PR makes the `AsCommand` attribute class final as it was marked `@final since Symfony 7.3`.